### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Philsopher Stone API
+# Philosopher Stone API
 
-This reposity contains API wrappers for access and interacting stock data.
+This repository contains API wrappers for access and interacting stock data.
 
 1. API wrapper for ib_insync
 2. API wrapper for ib_api


### PR DESCRIPTION
## Summary
- fix typos in README heading and description

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c9cf478648327bfeb01823d9f0b91